### PR TITLE
update GATK description

### DIFF
--- a/feat-content.html
+++ b/feat-content.html
@@ -29,7 +29,7 @@
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
            href="organizations/BroadInstitute/collections/GATKWorkflows">
             <h4 class="feat-content-title">GATK Best Practices Workflows</h4>
-            <p class="feat-card-description">A collection workflows for analyzing high-throughput sequencing data with a primary focus on variant discovery.</p>
+            <p class="feat-card-description">Developed in the Data Sciences Platform at the Broad Institute, the Genome Analysis Toolkit (GATK) offers a wide variety of tools with a primary focus on variant discovery and genotyping.</p>
         </a>
     </div>
 


### PR DESCRIPTION
Develop is currently live on the logged-in homepage of https://staging.dockstore.org/. Please review for content (also open to suggestions for other things to highlight instead or in the future). This PR should be merged before 1.8.0 release to production.

Currently the only  difference between this PR and staging is the [GATK](https://gatk.broadinstitute.org/hc/en-us) description (sourced from their site).

![image](https://user-images.githubusercontent.com/23464754/73403203-d0e51d00-42a3-11ea-986e-f681a2676d3f.png)

