### PR TITLE
feature github apps

### DIFF
--- a/feat-content.html
+++ b/feat-content.html
@@ -2,9 +2,9 @@
 
     <div class="feat-content-card">
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://bcc2020.github.io/">
-            <h4 class="feat-content-title">Bioinformatics Community Conference 2020</h4>
-            <p class="feat-card-description">Registration for BCC2020 is now open! Check out the full program and sign up for Dockstore's virtual workshops on Docker, Descriptors, and analysis with Terra.</p>
+           href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
+            <h4 class="feat-content-title">Dockstore Github App for Continuous Integration</h4>
+            <p class="feat-card-description">Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between Github and Dockstore. Checkout our guides for more details.</p>
         </a>
     </div>
 

--- a/feat-content.html
+++ b/feat-content.html
@@ -3,7 +3,7 @@
     <div class="feat-content-card">
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
            href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
-            <h4 class="feat-content-title">Dockstore GitHub App for Continuous Integration</h4>
+            <h4 class="feat-content-title">Dockstore GitHub App</h4>
             <p class="feat-card-description">Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore. Checkout our guides for more details.</p>
         </a>
     </div>

--- a/feat-content.html
+++ b/feat-content.html
@@ -3,8 +3,8 @@
     <div class="feat-content-card">
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
            href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
-            <h4 class="feat-content-title">Dockstore Github App for Continuous Integration</h4>
-            <p class="feat-card-description">Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between Github and Dockstore. Checkout our guides for more details.</p>
+            <h4 class="feat-content-title">Dockstore GitHub App for Continuous Integration</h4>
+            <p class="feat-card-description">Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore. Checkout our guides for more details.</p>
         </a>
     </div>
 


### PR DESCRIPTION
features dockstore github app links to [Dockstore GitHub App](https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html) landing page
![image](https://user-images.githubusercontent.com/23464754/95114706-32923c80-06f9-11eb-8125-a248bb522064.png)
