### PR TITLE
Testing split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,6 @@ jobs:
                               fi
                               echo ${S3_BUCKET_PATH}
                   - aws-s3/copy:
-                          from: '*.html'
+                          arguments: --recursive
+                          from: '.'
                           to: 's3://${AWS_BUCKET}/${S3_BUCKET_PATH}/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,6 @@ jobs:
                               fi
                               echo ${S3_BUCKET_PATH}
                   - aws-s3/copy:
-                          arguments: --include "*.html"
+                          arguments:  --recursive --exclude ".git/*"
                           from: '.'
                           to: 's3://${AWS_BUCKET}/${S3_BUCKET_PATH}/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,6 @@ jobs:
                               fi
                               echo ${S3_BUCKET_PATH}
                   - aws-s3/copy:
-                          arguments: --recursive --include "*.html"
+                          arguments: --include "*.html"
                           from: '.'
                           to: 's3://${AWS_BUCKET}/${S3_BUCKET_PATH}/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,6 @@ jobs:
                               fi
                               echo ${S3_BUCKET_PATH}
                   - aws-s3/copy:
-                          arguments: --recursive
+                          arguments: --recursive --include "*.html"
                           from: '.'
                           to: 's3://${AWS_BUCKET}/${S3_BUCKET_PATH}/'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # extra-content
-A repo for external content, such as featured content and news
+A repo for external content, such as featured content and news.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # extra-content
-A repo for external content, such as featured content
+A repo for external content, such as featured content and news

--- a/feat-content.html
+++ b/feat-content.html
@@ -1,13 +1,4 @@
 <div class="feat-content-container">
-
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
-            <h4 class="feat-content-title">Dockstore GitHub App</h4>
-            <p class="feat-card-description">Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</p>
-        </a>
-    </div>
-
     <div class="feat-content-card">
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
            href="organizations/BroadInstitute/collections/pgs">
@@ -15,21 +6,4 @@
             <p class="feat-card-description">A collection of viral NGS workflows for analyzing COVID-19. Learn how to use them with your own data in linked Terra workspaces from the Broad Viral Genomics & Data Sciences Platform.</p>
         </a>
     </div>
-
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://www.youtube.com/watch?v=1JWOVGzzgMc">
-            <h4 class="feat-content-title">Introduction to Dockstore Webinar</h4>
-            <p class="feat-card-description">A simple overview of the Dockstore platform and features. Covers the fundamentals of finding workflows and provides examples of running analysis with sample data.</p>
-        </a>
-    </div>
-        
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://www.youtube.com/watch?v=m8Tt0KemKFI">
-            <h4 class="feat-content-title">Conduct a COVID-19 Viral Genomics Analysis Using Dockstore and Terra</h4>
-            <p class="feat-card-description">This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</p>
-        </a>
-    </div>
-
 </div>

--- a/news.html
+++ b/news.html
@@ -1,21 +1,27 @@
 <span>
-    <h4> <a target="_blank" rel="noopener noreferrer"
+    <h4> 
+        <a target="_blank" rel="noopener noreferrer"
            href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
-    Dockstore GitHub App</h4>
+        Dockstore GitHub App</a>
+    </h4>
     <span>Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</span>
 </span>
     
 <span>
-    <h4> <a target="_blank" rel="noopener noreferrer"
+    <h4> 
+        <a target="_blank" rel="noopener noreferrer"
            href="https://www.youtube.com/watch?v=1JWOVGzzgMc">
            Introduction to Dockstore Webinar
+        </a>
     </h4>
     <span>A simple overview of the Dockstore platform and features. Covers the fundamentals of finding workflows and provides examples of running analysis with sample data.</span>
 </span>
         
 <span>        
-    <h4> <a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/watch?v=m8Tt0KemKFI"> 
+    <h4> 
+        <a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/watch?v=m8Tt0KemKFI"> 
         Conduct a COVID-19 Viral Genomics Analysis Using Dockstore and Terra
+        </a>
     </h4>
     <span>This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</span>
 </span>

--- a/news.html
+++ b/news.html
@@ -1,27 +1,22 @@
-<div class="news-content-container">
-    
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
+<span>
+    <h4> <a target="_blank" rel="noopener noreferrer"
            href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
-            <h4 class="feat-content-title">Dockstore GitHub App</h4>
-            <p class="feat-card-description">Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</p>
-        </a>
-    </div>
-
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://www.youtube.com/watch?v=1JWOVGzzgMc">
-            <h4 class="feat-content-title">Introduction to Dockstore Webinar</h4>
-            <p class="feat-card-description">A simple overview of the Dockstore platform and features. Covers the fundamentals of finding workflows and provides examples of running analysis with sample data.</p>
-        </a>
-    </div>
-        
-    <div class="feat-content-card">
-        <a class="cardClick" target="_blank" rel="noopener noreferrer"
-           href="https://www.youtube.com/watch?v=m8Tt0KemKFI">
-            <h4 class="feat-content-title">Conduct a COVID-19 Viral Genomics Analysis Using Dockstore and Terra</h4>
-            <p class="feat-card-description">This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</p>
-        </a>
-    </div>
+    Dockstore GitHub App</h4>
+    <span>Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</span>
+</span>
     
-</div>
+<span>
+    <h4> <a target="_blank" rel="noopener noreferrer"
+           href="https://www.youtube.com/watch?v=1JWOVGzzgMc">
+           Introduction to Dockstore Webinar
+    </h4>
+    <span>A simple overview of the Dockstore platform and features. Covers the fundamentals of finding workflows and provides examples of running analysis with sample data.</span>
+</span>
+        
+<span>        
+    <h4> <a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/watch?v=m8Tt0KemKFI"> 
+        Conduct a COVID-19 Viral Genomics Analysis Using Dockstore and Terra
+    </h4>
+    <span>This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</span>
+</span>
+   

--- a/news.html
+++ b/news.html
@@ -1,4 +1,5 @@
 <div class="news-content-container">
+    
     <div class="feat-content-card">
         <a class="cardClick" target="_blank" rel="noopener noreferrer"
            href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
@@ -22,4 +23,5 @@
             <p class="feat-card-description">This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</p>
         </a>
     </div>
+    
 </div>

--- a/news.html
+++ b/news.html
@@ -1,7 +1,7 @@
 <span>
     <h4> 
         <a target="_blank" rel="noopener noreferrer"
-           href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
+           href="https://docs.dockstore.org/en/stable/getting-started/github-apps/github-apps-landing-page.html">
         Dockstore GitHub App</a>
     </h4>
     <span>Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</span>

--- a/news.html
+++ b/news.html
@@ -4,7 +4,16 @@
            href="https://docs.dockstore.org/en/stable/getting-started/github-apps/github-apps-landing-page.html">
         Dockstore GitHub App</a>
     </h4>
-    <span>Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</span>
+    <span>Updated: Now with control over publishing status and updating the default (display) version. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</span>
+</span>
+
+<span>
+    <h4> 
+        <a target="_blank" rel="noopener noreferrer"
+           href="https://github.com/dockstore/dockstore/releases/tag/1.11.5">
+        1.11 release</a>
+    </h4>
+    <span>Get more information on our 1.11.x series releases here.</span>
 </span>
     
 <span>

--- a/news.html
+++ b/news.html
@@ -1,0 +1,25 @@
+<div class="news-content-container">
+    <div class="feat-content-card">
+        <a class="cardClick" target="_blank" rel="noopener noreferrer"
+           href="https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps-landing-page.html">
+            <h4 class="feat-content-title">Dockstore GitHub App</h4>
+            <p class="feat-card-description">Updated: Now with filters that let you selectively choose which branches to sync. Our new Dockstore GitHub App adds support for registering and automatically syncing workflows and services between GitHub and Dockstore.</p>
+        </a>
+    </div>
+
+    <div class="feat-content-card">
+        <a class="cardClick" target="_blank" rel="noopener noreferrer"
+           href="https://www.youtube.com/watch?v=1JWOVGzzgMc">
+            <h4 class="feat-content-title">Introduction to Dockstore Webinar</h4>
+            <p class="feat-card-description">A simple overview of the Dockstore platform and features. Covers the fundamentals of finding workflows and provides examples of running analysis with sample data.</p>
+        </a>
+    </div>
+        
+    <div class="feat-content-card">
+        <a class="cardClick" target="_blank" rel="noopener noreferrer"
+           href="https://www.youtube.com/watch?v=m8Tt0KemKFI">
+            <h4 class="feat-content-title">Conduct a COVID-19 Viral Genomics Analysis Using Dockstore and Terra</h4>
+            <p class="feat-card-description">This workshop video covers the basics of the Dockstore and Terra platforms, and then instructs users on how to use the AnVIL ecosystem to conduct a viral genomics analysis with publicly available raw Covid sequence data.</p>
+        </a>
+    </div>
+</div>


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-2915

Merge only when production is ready for this content
This implements the split between news and events with featured content. 
However, prod is actually using develop so block this for now

Staging can test with https://content.dockstore.org/test/testing_split/feat-content.html and https://content.dockstore.org/test/testing_split/news.html

Reviewers, reject this for now to be safe