### PR TITLE
Update News Style for News Widget

### DIFF
--- a/news.html
+++ b/news.html
@@ -1,49 +1,49 @@
 <div fxLayout="column" fxLayoutAlign="space-between" class="h-100">
-    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-      <span>
-        <h5 class="mb-0">
-            <a target="_blank" rel="noopener noreferrer"
-                href="https://medium.com/dockstore/dockstore-achieves-the-best-available-security-standard-in-the-industry-ce194b017089">
-            Dockstore achieves best available security standard</a>
-        </h5>
-        <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
-      </span>
-      <span class="date-display ml-2">Aug 1, 2022</span>
-    </div>
-    <mat-divider class="my-3"></mat-divider>
-    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-      <span>
-        <h5 class="mb-0">
-            <a target="_blank" rel="noopener noreferrer"
-                href="https://www.youtube.com/watch?v=GWBg8gJDpiw">
-            Latest webinar from Dockstore</a>
-        </h5>
-        <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
-      </span>
-      <span class="date-display ml-2">Jun 28, 2022</span>
-    </div>
-    <mat-divider class="my-3"></mat-divider>
-    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-      <span>
-        <h5 class="mb-0">
-            <a target="_blank" rel="noopener noreferrer"
-                href="https://medium.com/dockstore/out-with-the-old-in-with-the-tools-1ad78132822d">
-            Dockstore releases a simplified tool definition in 1.12</a>
-        </h5>
-        <span>Read more about changes in 1.12 in our blog post.</span>
-      </span>
-      <span class="date-display ml-2">May 3, 2022</span>
-    </div>
-    <mat-divider class="my-3"></mat-divider>
-    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-      <span>
-        <h5 class="mb-0">
-            <a target="_blank" rel="noopener noreferrer"
-                href="https://github.com/dockstore/dockstore/releases/tag/1.12.0">
-            1.12 release</a>
-        </h5>
-        <span>Get more information on our 1.12.x series releases here.</span>
-      </span>
-      <span class="date-display ml-2">Mar 28, 2022</span>
-    </div>
+  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+    <span>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
+              href="https://medium.com/dockstore/dockstore-achieves-the-best-available-security-standard-in-the-industry-ce194b017089">
+          Dockstore achieves best available security standard</a>
+      </h5>
+      <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
+    </span>
+    <span class="date-display ml-2">Aug 1, 2022</span>
   </div>
+  <mat-divider class="my-3"></mat-divider>
+  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+    <span>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
+              href="https://www.youtube.com/watch?v=GWBg8gJDpiw">
+          Latest webinar from Dockstore</a>
+      </h5>
+      <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
+    </span>
+    <span class="date-display ml-2">Jun 28, 2022</span>
+  </div>
+  <mat-divider class="my-3"></mat-divider>
+  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+    <span>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
+              href="https://medium.com/dockstore/out-with-the-old-in-with-the-tools-1ad78132822d">
+          Dockstore releases a simplified tool definition in 1.12</a>
+      </h5>
+      <span>Read more about changes in 1.12 in our blog post.</span>
+    </span>
+    <span class="date-display ml-2">May 3, 2022</span>
+  </div>
+  <mat-divider class="my-3"></mat-divider>
+  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+    <span>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
+              href="https://github.com/dockstore/dockstore/releases/tag/1.12.0">
+          1.12 release</a>
+      </h5>
+      <span>Get more information on our 1.12.x series releases here.</span>
+    </span>
+    <span class="date-display ml-2">Mar 28, 2022</span>
+  </div>
+</div>

--- a/news.html
+++ b/news.html
@@ -1,49 +1,49 @@
 <div fxLayout="column" fxLayoutAlign="space-between" class="h-100">
   <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-    <span>
+    <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
               href="https://medium.com/dockstore/dockstore-achieves-the-best-available-security-standard-in-the-industry-ce194b017089">
           Dockstore achieves best available security standard</a>
       </h5>
       <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
-    </span>
+    </div>
     <span class="date-display ml-2">Aug 1, 2022</span>
   </div>
   <mat-divider class="my-3"></mat-divider>
   <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-    <span>
+    <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
               href="https://www.youtube.com/watch?v=GWBg8gJDpiw">
           Latest webinar from Dockstore</a>
       </h5>
       <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
-    </span>
+    </div>
     <span class="date-display ml-2">Jun 28, 2022</span>
   </div>
   <mat-divider class="my-3"></mat-divider>
   <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-    <span>
+    <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
               href="https://medium.com/dockstore/out-with-the-old-in-with-the-tools-1ad78132822d">
           Dockstore releases a simplified tool definition in 1.12</a>
       </h5>
       <span>Read more about changes in 1.12 in our blog post.</span>
-    </span>
+    </div>
     <span class="date-display ml-2">May 3, 2022</span>
   </div>
   <mat-divider class="my-3"></mat-divider>
   <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
-    <span>
+    <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
               href="https://github.com/dockstore/dockstore/releases/tag/1.12.0">
           1.12 release</a>
       </h5>
       <span>Get more information on our 1.12.x series releases here.</span>
-    </span>
+    </div>
     <span class="date-display ml-2">Mar 28, 2022</span>
   </div>
 </div>

--- a/news.html
+++ b/news.html
@@ -1,44 +1,49 @@
-<span>
-    <h4>
-        <a target="_blank" rel="noopener noreferrer"
-           href="https://medium.com/dockstore/dockstore-achieves-the-best-available-security-standard-in-the-industry-ce194b017089">
-        Dockstore achieves best available security standard</a>
-    </h4>
-    <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
-</span>
-
-<span>
-    <h4>
-        <a target="_blank" rel="noopener noreferrer"
-           href="https://www.youtube.com/watch?v=GWBg8gJDpiw">
-        Latest webinar from Dockstore</a>
-    </h4>
-    <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
-</span>
-
-<span>
-    <h4>
-        <a target="_blank" rel="noopener noreferrer"
-           href="https://medium.com/dockstore/out-with-the-old-in-with-the-tools-1ad78132822d">
-        Dockstore releases a simplified tool definition in 1.12</a>
-    </h4>
-    <span>Read more about changes in 1.12 in our blog post.</span>
-</span>
-
-<span>
-    <h4>
-        <a target="_blank" rel="noopener noreferrer"
-           href="https://github.com/dockstore/dockstore/releases/tag/1.12.0">
-        1.12 release</a>
-    </h4>
-    <span>Get more information on our 1.12.x series releases here.</span>
-</span>
-
-<span>
-    <h4>
-        <a target="_blank" rel="noopener noreferrer"
-           href="https://medium.com/dockstore/dockstore-partners-with-aws-agc-to-make-launching-workflows-quick-and-easy-7213510dabd8">
-        Launch Dockstore workflows with AWS Genomics CLI</a>
-    </h4>
-    <span>Learn about our new partnership with Amazon Web Services Genomics CLI.</span>
-</span>
+<div fxLayout="column" fxLayoutAlign="space-between" class="h-100">
+    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+      <span>
+        <h5 class="mb-0">
+            <a target="_blank" rel="noopener noreferrer"
+                href="https://medium.com/dockstore/dockstore-achieves-the-best-available-security-standard-in-the-industry-ce194b017089">
+            Dockstore achieves best available security standard</a>
+        </h5>
+        <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
+      </span>
+      <span class="date-display ml-2">Aug 1, 2022</span>
+    </div>
+    <mat-divider class="my-3"></mat-divider>
+    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+      <span>
+        <h5 class="mb-0">
+            <a target="_blank" rel="noopener noreferrer"
+                href="https://www.youtube.com/watch?v=GWBg8gJDpiw">
+            Latest webinar from Dockstore</a>
+        </h5>
+        <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
+      </span>
+      <span class="date-display ml-2">Jun 28, 2022</span>
+    </div>
+    <mat-divider class="my-3"></mat-divider>
+    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+      <span>
+        <h5 class="mb-0">
+            <a target="_blank" rel="noopener noreferrer"
+                href="https://medium.com/dockstore/out-with-the-old-in-with-the-tools-1ad78132822d">
+            Dockstore releases a simplified tool definition in 1.12</a>
+        </h5>
+        <span>Read more about changes in 1.12 in our blog post.</span>
+      </span>
+      <span class="date-display ml-2">May 3, 2022</span>
+    </div>
+    <mat-divider class="my-3"></mat-divider>
+    <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+      <span>
+        <h5 class="mb-0">
+            <a target="_blank" rel="noopener noreferrer"
+                href="https://github.com/dockstore/dockstore/releases/tag/1.12.0">
+            1.12 release</a>
+        </h5>
+        <span>Get more information on our 1.12.x series releases here.</span>
+      </span>
+      <span class="date-display ml-2">Mar 28, 2022</span>
+    </div>
+  </div>


### PR DESCRIPTION
Updates the style of the news entries to:

- display the date the article was published
- add dividing lines
- limit to 4 articles instead of 5
- match the layout to the [mocks](https://www.figma.com/file/MyPLx5xoj2FCqO47jR23ZD/New-Dashboard%3A-News-and-Twitter-Widget-Designs?node-id=0%3A1&t=IAC09Y8o2Z1sZ69V-1)

`news.html` will be embedded in the new `news-box.component` to display on the new dashboard:

![image](https://user-images.githubusercontent.com/97123241/223772234-4a0fc6d1-106f-4337-b084-7984d450b9bd.png)

Embedded on the homepage without the box:
![image](https://user-images.githubusercontent.com/97123241/223774658-d6401b57-9dab-471b-80fa-e7e6349b3383.png)

Ticket: [SEAB-5200](https://ucsc-cgl.atlassian.net/browse/SEAB-5200?atlOrigin=eyJpIjoiODVlNjU4NjQyZmI0NDdlYmEwYTVhY2NjZWE3YmY2MTEiLCJwIjoiaiJ9)


[SEAB-5200]: https://ucsc-cgl.atlassian.net/browse/SEAB-5200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ