### PR TITLE
News Style Fix - Revert to Plain HTML

### DIFF
--- a/news.html
+++ b/news.html
@@ -1,5 +1,5 @@
-<div fxLayout="column" fxLayoutAlign="space-between" class="h-100">
-  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+<div class="news-and-updates-box h-100">
+  <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
@@ -8,10 +8,9 @@
       </h5>
       <span>Learn more about our journey to NIST-800-53 compliance in our blog post.</span>
     </div>
-    <span class="date-display ml-2">Aug 1, 2022</span>
+    <span class="date-display ml-3">Aug 1, 2022</span>
   </div>
-  <mat-divider class="my-3"></mat-divider>
-  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+  <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
@@ -20,10 +19,9 @@
       </h5>
       <span>Watch our latest webinar introducting Dockstore to the eLwazi Consortium.</span>
     </div>
-    <span class="date-display ml-2">Jun 28, 2022</span>
+    <span class="date-display ml-3">Jun 28, 2022</span>
   </div>
-  <mat-divider class="my-3"></mat-divider>
-  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+  <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
@@ -32,10 +30,9 @@
       </h5>
       <span>Read more about changes in 1.12 in our blog post.</span>
     </div>
-    <span class="date-display ml-2">May 3, 2022</span>
+    <span class="date-display ml-3">May 3, 2022</span>
   </div>
-  <mat-divider class="my-3"></mat-divider>
-  <div fxLayout fxLayout.lt-sm="row wrap" fxLayoutAlign="space-between end">
+  <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
@@ -44,6 +41,6 @@
       </h5>
       <span>Get more information on our 1.12.x series releases here.</span>
     </div>
-    <span class="date-display ml-2">Mar 28, 2022</span>
+    <span class="date-display ml-3">Mar 28, 2022</span>
   </div>
 </div>


### PR DESCRIPTION
[SEAB-5339](https://ucsc-cgl.atlassian.net/browse/SEAB-5339?atlOrigin=eyJpIjoiMTg1MmNkZWE1MmUyNGM2NGE1NjI5ZjY5NjNmMjA1MzgiLCJwIjoiaiJ9) Noticed when looking at qa that the new styles for `News & Updates` wasn't looking right... realized the Angular elements added to `news.html` weren't being rendered (missing `mat-divider` and `fxLayout`).

Reverting the file to use plain `html` and will add the relevant styles with `css` in `styles.scss`, mainly adds bottom borders and `flex-box` styles (I'll put a pr up for the UI soon).

Adding new classes:

- `news-and-updates-box`
- `news-entry`

That will be used to style in the UI.

**Currently in QA:**
![image](https://user-images.githubusercontent.com/97123241/226984163-234a67d9-e4ec-40ea-a4b1-552e19fb1091.png)

**Final changes with plain html and css styles:**
 ![image](https://user-images.githubusercontent.com/97123241/226983837-5c21fe6e-a934-45f1-a03c-c54ff59d1522.png)


[SEAB-5339]: https://ucsc-cgl.atlassian.net/browse/SEAB-5339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ