### PR TITLE
Mention new trs-notebook example in Notebooks update

### DIFF
--- a/news.html
+++ b/news.html
@@ -17,9 +17,9 @@
              href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html">
               Notebooks</a>
       </h5>
-        <span>Learn how to register notebooks in Dockstore. Explore an <a target="_blank" rel="noopener noreferrer"
+        <span>Learn how to register notebooks in Dockstore. For a fun example of a notebook on Dockstore, explore this <a target="_blank" rel="noopener noreferrer"
             href="https://dockstore.org/notebooks/github.com/dockstore/dockstore-trs-notebook:main?tab=info">
-            example notebook</a> that demonstrates how to use the TRS API.</span>
+            notebook</a> that demonstrates how to use the TRS API.</span>
     </div>
     <span class="date-display ml-3">Feb 8, 2024</span>
   </div>

--- a/news.html
+++ b/news.html
@@ -17,7 +17,7 @@
              href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html">
               Notebooks</a>
       </h5>
-        <span>Learn how to register notebooks in Dockstore. View an <a target="_blank" rel="noopener noreferrer"
+        <span>Learn how to register notebooks in Dockstore. Explore an <a target="_blank" rel="noopener noreferrer"
             href="https://dockstore.org/notebooks/github.com/dockstore/dockstore-trs-notebook:main?tab=info">
             example notebook</a> that demonstrates how to use the TRS API.</span>
     </div>

--- a/news.html
+++ b/news.html
@@ -17,7 +17,9 @@
              href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html">
               Notebooks</a>
       </h5>
-        <span>Learn how to register notebooks in Dockstore</span>
+        <span>Learn how to register notebooks in Dockstore. View an <a target="_blank" rel="noopener noreferrer"
+            href="https://dockstore.org/notebooks/github.com/dockstore/dockstore-trs-notebook:main?tab=info">
+            example notebook</a> that demonstrates how to use the TRS API.</span>
     </div>
     <span class="date-display ml-3">Feb 8, 2024</span>
   </div>


### PR DESCRIPTION
I created a notebook that demonstrates how to use the TRS API in [this repository](https://github.com/dockstore/dockstore-trs-notebook/blob/main/trs-notebook.ipynb) and registered it to Dockstore. 

This PR mentions this notebook in the News And Updates section in the existing Notebooks news entry.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6079