### PR TITLE
Reference simple notebook example in news entry

### DIFF
--- a/news.html
+++ b/news.html
@@ -18,7 +18,7 @@
               Notebooks</a>
       </h5>
         <span>Learn how to register notebooks in Dockstore. For a simple notebook example, explore this <a target="_blank" rel="noopener noreferrer"
-          href="https://dockstore.org/notebooks/github.com/dockstore/notebook-example/running-code:main?tab=info">
+          href="https://dockstore.org/notebooks/github.com/dockstore/example-notebook/running-code:main?tab=info">
           notebook</a> that demonstrates how to run code in a notebook.</span>
     </div>
     <span class="date-display ml-3">Feb 8, 2024</span>

--- a/news.html
+++ b/news.html
@@ -17,7 +17,9 @@
              href="https://docs.dockstore.org/en/stable/getting-started/getting-started-with-notebooks.html">
               Notebooks</a>
       </h5>
-        <span>Learn how to register notebooks in Dockstore</span>
+        <span>Learn how to register notebooks in Dockstore. For a simple notebook example, explore this <a target="_blank" rel="noopener noreferrer"
+          href="https://dockstore.org/notebooks/github.com/dockstore/notebook-example/running-code:main?tab=info">
+          notebook</a> that demonstrates how to run code in a notebook.</span>
     </div>
     <span class="date-display ml-3">Feb 8, 2024</span>
   </div>


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-6274

This PR is similar to https://github.com/dockstore/extra-content/pull/54, except I registered a simpler notebook on Dockstore that is compatible with all of our notebook launch options.

The notebook can be found [here](https://dockstore.org/notebooks/github.com/dockstore/example-notebook/running-code:main?tab=info) and it is a copy of Jupyter's [Running Code notebook example](https://github.com/jupyter/notebook/tree/main/docs/source/examples/Notebook).