### PR TITLE
Add 1.16 release news

### DIFF
--- a/news.html
+++ b/news.html
@@ -3,6 +3,17 @@
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
+             href="https://github.com/dockstore/dockstore/releases/tag/1.16.0">
+              1.16 release</a>
+      </h5>
+        <span>Get more information on our 1.16.x series releases here.</span>
+    </div>
+    <span class="date-display ml-3">November 7, 2024</span>
+  </div>
+  <div class="news-entry py-3">
+    <div>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
              href="https://www.iscb.org/cms_addon/conferences/ismb2024/posters.php?track=BOSC&session=D#search">
               ISMB/BOSC 2024</a>
       </h5>
@@ -44,16 +55,5 @@
         <span>See workflows' executions and durations on different platforms</span>
     </div>
     <span class="date-display ml-3">Feb 8, 2024</span>
-  </div>
-  <div class="news-entry py-3">
-    <div>
-      <h5 class="mb-0">
-          <a target="_blank" rel="noopener noreferrer"
-             href="https://github.com/dockstore/dockstore/releases/tag/1.14.0">
-              1.14 release</a>
-      </h5>
-        <span>Get more information on our 1.14.x series releases here.</span>
-    </div>
-    <span class="date-display ml-3">May 31, 2023</span>
   </div>
 </div>


### PR DESCRIPTION
Added news about 1.16 release.

There's no good link at this point I'm aware of for AI topics or auto DOI generation, so no changes to
featured content at this point.