### PR TITLE
SEAB-6938: Announce automatic DOIs + misc fixes

### DIFF
--- a/news.html
+++ b/news.html
@@ -31,7 +31,7 @@
              href="https://github.com/dockstore/dockstore/releases?q=tag%3A1.16">
               1.16 release</a>
       </h5>
-        <span>Get more information on our 1.16.x series releases <a target="_blank" rel="noopener noreferrer" href=href="https://github.com/dockstore/dockstore/releases?q=tag%3A1.16">here</a>.</span>
+        <span>Get more information on our 1.16.x series releases <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockstore/dockstore/releases?q=tag%3A1.16">here</a>.</span>
     </div>
     <span class="date-display ml-3">Nov 7, 2024</span>
   </div>

--- a/news.html
+++ b/news.html
@@ -1,5 +1,17 @@
 <div class="news-and-updates-box h-100">
- <div class="news-entry py-3">
+  <div class="news-entry py-3">
+    <div>
+      <h5 class="mb-0">
+          <a target="_blank" rel="noopener noreferrer"
+             href="https://docs.dockstore.org/en/stable/end-user-topics/dois.html#automatic-dockstore-doi-generation">
+              Automatic DOIs</a>
+      </h5>
+        <span>Dockstore now automatically generates a Zenodo DOI for a tagged version when it is added to a published entry.  See the <a target="_blank" rel="noopener noreferrer"
+          href="https://docs.dockstore.org/en/stable/end-user-topics/dois.html#automatic-dockstore-doi-generation">details</a>!</span>
+    </div>
+    <span class="date-display ml-3">Feb 19, 2025</span>
+  </div>
+  <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
@@ -8,7 +20,7 @@
       </h5>
         <span>Terra metrics through the end of 2024 have been loaded! Check on how people are using the various versions of your workflows on <a target="_blank" rel="noopener noreferrer"
           href="https://dockstore.org/search?execution_partners.keyword=TERRA&entryType=workflows&searchMode=files">
-          Terra</a></span>
+          Terra</a>.</span>
     </div>
     <span class="date-display ml-3">Jan 15, 2025</span>
   </div>
@@ -16,12 +28,12 @@
     <div>
       <h5 class="mb-0">
           <a target="_blank" rel="noopener noreferrer"
-             href="https://github.com/dockstore/dockstore/releases/tag/1.16.0">
+             href="https://github.com/dockstore/dockstore/releases?q=tag%3A1.16">
               1.16 release</a>
       </h5>
-        <span>Get more information on our 1.16.x series releases here.</span>
+        <span>Get more information on our 1.16.x series releases <a target="_blank" rel="noopener noreferrer" href=href="https://github.com/dockstore/dockstore/releases?q=tag%3A1.16">here</a>.</span>
     </div>
-    <span class="date-display ml-3">November 7, 2024</span>
+    <span class="date-display ml-3">Nov 7, 2024</span>
   </div>
   <div class="news-entry py-3">
     <div>
@@ -32,19 +44,8 @@
       </h5>
         <span>Drop by our poster at the ISMB/BOSC poster session D in Montreal to chat!</span>
     </div>
-    <span class="date-display ml-3">July 9, 2024</span>
+    <span class="date-display ml-3">Jul 9, 2024</span>
   </div>  
-  <div class="news-entry py-3">
-    <div>
-      <h5 class="mb-0">
-          <a target="_blank" rel="noopener noreferrer"
-             href="https://github.com/dockstore/dockstore/releases/tag/1.15.0">
-              1.15 release</a>
-      </h5>
-        <span>Get more information on our 1.15.x series releases here.</span>
-    </div>
-    <span class="date-display ml-3">Feb 8, 2024</span>
-  </div>
   <div class="news-entry py-3">
     <div>
       <h5 class="mb-0">


### PR DESCRIPTION
This PR adds an item to the top of Dockstore's "News & Updates" section that announces the general roll-out of the "automatic DOI" feature.

It also changes the existing content so that:
* all sentences end with punctuation.
* the date formatting is consistent.
* the "1.16.x" URL lists all releases in the 1.16 series, rather than 1.16.0 only.

Additionally, it links the "here" text in the 1.16 item, per typical practice.


