### PR TITLE
Fix View buttons in Featured Content

### DIFF
--- a/feat-content.html
+++ b/feat-content.html
@@ -7,7 +7,7 @@
             <p class="feat-card-description p-1">This organization continually adds workflows used to build the Human Pangenome Reference. Learn how to use the latest pangenome reference with the tutorial linked on their page.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="organizations/HumanPangenome" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
+            <a href="organizations/HumanPangenome" class="mat-mdc-raised-button mdc-button small-btn-structure mat-accent no-underline">View</a>
         </div>  
     </div>
     <div class="feat-content-card p-4">
@@ -18,7 +18,7 @@
             <p class="feat-card-description p-1">WARP pipelines are rigorously tested, scientifically validated, reproducible and open source. They process a range of “omic” and array-related datasets, including whole genomic, exomic, single cell transciptomic, and epigenomic.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="organizations/BroadInstitute/collections/WARPpipelines" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
+            <a href="organizations/BroadInstitute/collections/WARPpipelines" class="mat-mdc-raised-button mdc-button small-btn-structure mat-accent no-underline">View</a>
         </div> 
     </div>
     <div class="feat-content-card p-4">
@@ -29,7 +29,7 @@
             <p class="feat-card-description p-1">A webinar with tips for how to build a FAIR workflow on Dockstore.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="https://www.youtube.com/watch?v=S6nK8I-8JEI&list=PLSIGopyrrU83YUisJHl95BMVj2kw6cDF9&index=21" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
+            <a href="https://www.youtube.com/watch?v=S6nK8I-8JEI&list=PLSIGopyrrU83YUisJHl95BMVj2kw6cDF9&index=21" class="mat-mdc-raised-button mdc-button small-btn-structure mat-accent no-underline">View</a>
         </div> 
     </div>
 </div>

--- a/feat-content.html
+++ b/feat-content.html
@@ -7,7 +7,7 @@
             <p class="feat-card-description p-1">This organization continually adds workflows used to build the Human Pangenome Reference. Learn how to use the latest pangenome reference with the tutorial linked on their page.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="organizations/HumanPangenome" class="mat-raised-button small-btn-structure mat-accent no-underline">View</a>
+            <a href="organizations/HumanPangenome" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
         </div>  
     </div>
     <div class="feat-content-card p-4">
@@ -18,7 +18,7 @@
             <p class="feat-card-description p-1">WARP pipelines are rigorously tested, scientifically validated, reproducible and open source. They process a range of “omic” and array-related datasets, including whole genomic, exomic, single cell transciptomic, and epigenomic.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="organizations/BroadInstitute/collections/WARPpipelines" class="mat-raised-button small-btn-structure mat-accent no-underline">View</a>
+            <a href="organizations/BroadInstitute/collections/WARPpipelines" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
         </div> 
     </div>
     <div class="feat-content-card p-4">
@@ -29,7 +29,7 @@
             <p class="feat-card-description p-1">A webinar with tips for how to build a FAIR workflow on Dockstore.</p>
         </a>
         <div class="feat-card-btn-container">
-            <a href="https://www.youtube.com/watch?v=S6nK8I-8JEI&list=PLSIGopyrrU83YUisJHl95BMVj2kw6cDF9&index=21" class="mat-raised-button small-btn-structure mat-accent no-underline">View</a>
+            <a href="https://www.youtube.com/watch?v=S6nK8I-8JEI&list=PLSIGopyrrU83YUisJHl95BMVj2kw6cDF9&index=21" mat-raised-button class="small-btn-structure mat-accent no-underline">View</a>
         </div> 
     </div>
 </div>


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-7084

This PR fixes the View buttons in the Featured Content cards so that they look like buttons. Due to the UI's Angular Material component migration https://github.com/dockstore/dockstore-ui2/pull/2052, the internal Material classes applied to the View button no longer exist which made the buttons not look like buttons.

Before
![image](https://github.com/user-attachments/assets/005ffb1c-07b6-4cd7-aad6-e4678f281b56)

After
![image](https://github.com/user-attachments/assets/b18100f6-a0b7-4460-a984-985f79e2bc9e)
